### PR TITLE
Convert `nav *` elements to using responsive view-widths

### DIFF
--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -22,9 +22,9 @@ nav {
 }
 
 nav * {
-    margin-right: 20px; /* TODO CONVERT TO VW, SO IT IS RESPONSIVE */
-    margin-left: 20px;
-    width: 150px;
+    margin-right: 0.1vw;
+    margin-left: 0.1vw;
+    width: 15vw;
     text-align: center;
 }
 


### PR DESCRIPTION
On viewports that are too thin, the elements may still stack up on one another and clip out of the viewport, but that was the case before these changes.

Addresses the (now-deleted) TODO comment.